### PR TITLE
Document Roundup handling of builds on "fresh" repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ Currently the process to create more formal release notes and attach Assets is d
 *NOTE: Be sure to add the `tar.gz` and `zip` from the `target/` directory to the release assets, and use the CHANGELOG generated above to create the RELEASE NOTES.*
 
 
+### CI/CD
+The template repository comes with our two "standard" CI/CD workflows, `stable-cicd` and `unstable-cicd`. The unstable build runs on any push to `main` (+/- ignoring changes to specific files) and the stable build runs on push of a release branch of the form `release/<release version>`. Both of these make use of our GitHub actions build step, [Roundup](https://github.com/NASA-PDS/roundup-action). The `unstable-cicd` will generate (and constantly update) a SNAPSHOT release. If you haven't done a formal software release you will end up with a `v0.0.0-SNAPSHOT` release (see NASA-PDS/roundup-action#56 for specifics). Additionally, tests are executed on any non-`main` branch push via `branch-cicd`.
+
+
 ## 📃 License
 
 The project is licensed under the [Apache version 2](LICENSE.md) license. Or it isn't. Change this after consulting with your lawyers.


### PR DESCRIPTION
Add a section describing the included CI/CD workflows and the
idiosyncrasies around builds on repositories without existing tags
from which to extract new version numbers.

Resolve #18
