### PR TITLE
Harmonize with the `pds-template-repo-python`

### DIFF
--- a/.github/workflows/branch-cicd.yaml
+++ b/.github/workflows/branch-cicd.yaml
@@ -59,7 +59,7 @@ jobs:
                 uses: actions/setup-java@v2
                 with:
                     distribution: 'adopt'
-                    java-version: ${{ matrix.java-version }}
+                    java-version: ${{matrix.java-version}}
             -
                 name: 🩺 Test Software
                 run: mvn test

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,6 @@
 # Static libraries
 *.lib
 *.a
-*.so
 
 # Eclipse files
 .settings/
@@ -50,7 +49,7 @@
 *.iml
 
 # Sublime Text files
-*.sublime-workspace
+*.sublime-*
 
 # Shared objects (inc. Windows DLLs)
 *.dll
@@ -65,12 +64,14 @@
 
 # Temporary files
 *~
+.*.swp
+var/
 
 # other stuff
 *.xpr
 *.swp
-/bin/
-.*.swp
+bin/
+typescript
 
 # Java stuff
 *.javac
@@ -79,3 +80,5 @@ target/
 
 # macOS specific stuff
 .DS_Store
+._*
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,13 +6,13 @@ This document describes the security policy of My Project. (Please update this f
 
 Use this section to tell people about which versions of your project are currently being supported with security updates; for example, with a table like the following:
 
-| Version | Supported          |
-|:--------|:------------------:|
-| 2.1.3   | ✅                 |
-| 2.1.4   | ✅                 |
-| <2.0    | ❌                 |
+| Version | Supported |
+|:--------|:---------:|
+| 2.1.4   | ✅        |
+| 2.1.3   | ✅        |
+| <2.0    | ❌        |
 
 
 ## 🚨 Reporting a Vulnerability
 
-Please fill in here what the right way to report a vulnerability is for your project; it might be submitting an issue of a specific type on GitHub, for example.
+To report a vulnerability, [please submit an issue on our tracker](https://github.com/NASA-PDS/<TODO: put project ID here>/issues/new?template=vulnerability-issue.md).


### PR DESCRIPTION
## 🗒️ Summary

During the Template Rollout Summer 2021 event, I've noticed some divergence between the `pds-template-repo-java` and the `pds-template-repo-python`. This commit helps close the gap between the two template repositories.

## ⚙️ Test Data and/or Report
```console
$ mvn test
[INFO] Scanning for projects...
…
[INFO] BUILD SUCCESS
…
$ echo \U+1F389
🎉
```

## ♻️ Related Issues

- NASA-PDS/devops#10

